### PR TITLE
Add support for custom watch function

### DIFF
--- a/spec/hound.spec.js
+++ b/spec/hound.spec.js
@@ -152,6 +152,14 @@ describe('Hound', function() {
     fs.mkdirSync(dir)
   })
 
+  it('can specify custom watch function', function() {
+    var file = testDir + '/file 1.js'
+      , works = false
+      , watchFn = function(src) { works = src }
+    watcher = hound.watch(file, {watchFn: watchFn})
+    expect(works).toBe(file)
+  })
+
   it('shouldn\'t raise two events for one create', function(done) {
     var file = testDir + '/subdir 1/subdir file 5.js'  
     var createCount = 0


### PR DESCRIPTION
Network filesystems don't like `fs.watch`. This change makes it possible to optionally use a custom watch function (eg: `fs.watchFile`).
